### PR TITLE
Multi-line description bug

### DIFF
--- a/ics.js
+++ b/ics.js
@@ -163,7 +163,7 @@ var ics = function() {
             var calendarEvent = [
                 'BEGIN:VEVENT',
                 'CLASS:PUBLIC',
-                'DESCRIPTION:' + description,
+                'DESCRIPTION:' + description.replace('\r\n', '\\n'),
                 'DTSTART:' + start,
                 'DTEND:' + end,
                 'DTSTAMP:' + stamp.substring(0, stamp.length - 13).replace(/[-]/g, '') + '000000Z',


### PR DESCRIPTION
I have multi-line descriptions in the calendar I'm exporting from. When I try to import the file that your ics.js program generates into Outlook or Google Calendar, it only pulls in the first line in and it ignores the rest. My solution fixes this. I tested it in both Outlook and Google Calendar and it works and also follows generally accepted ics file formatting standards I believe. As far as I can tell, it doesn't seem to break anything.

Let me know what you think.
Thanks.